### PR TITLE
Updating Due Dates Less Often

### DIFF
--- a/src/commands/DueDates/displayDueDates.ts
+++ b/src/commands/DueDates/displayDueDates.ts
@@ -64,6 +64,6 @@ module.exports = class DisplayDueDatesCommand extends Command {
             category: categoryArg.value,
         });
 
-        await job.repeatEvery('10 seconds').save();
+        await job.repeatEvery('60 seconds').save();
     }
 };


### PR DESCRIPTION
Updating every 10 seconds was excessive and may be the cause for some of the issues that we have been experencing.

Due dates are automatically updated when a due date is added or removed, immediately, so this will not cause delay in updates.